### PR TITLE
Store solver tol/itmx as Poisson struct defaults

### DIFF
--- a/src/MultiLevelPoisson.jl
+++ b/src/MultiLevelPoisson.jl
@@ -48,14 +48,16 @@ struct MultiLevelPoisson{T,S<:AbstractArray{T},V<:AbstractArray{T}} <: AbstractP
     levels :: Vector{Poisson{T,S,V}}
     n :: Vector{Int16}
     perdir :: NTuple # direction of periodic boundary condition
-    function MultiLevelPoisson(x::AbstractArray{T},L::AbstractArray{T},z::AbstractArray{T};maxlevels=10,perdir=()) where T
+    tol :: T # default solver tolerance
+    itmx :: Int # default maximum solver iterations
+    function MultiLevelPoisson(x::AbstractArray{T},L::AbstractArray{T},z::AbstractArray{T};maxlevels=10,perdir=(),tol=1e-4,itmx=32) where T
         levels = Poisson[Poisson(x,L,z;perdir)]
         while divisible(levels[end]) && length(levels) <= maxlevels
             push!(levels,restrictML(levels[end]))
         end
         text = "MultiLevelPoisson requires size=a2ⁿ, where n>2"
         @assert (length(levels)>2) text
-        new{T,typeof(x),typeof(L)}(x,L,z,levels,[],perdir)
+        new{T,typeof(x),typeof(L)}(x,L,z,levels,[],perdir,T(tol),Int(itmx))
     end
 end
 
@@ -86,7 +88,7 @@ residual!(ml::MultiLevelPoisson,x) = residual!(ml.levels[1],x)
 
 smooth! = GaussSeidelRB!
 
-function solver!(ml::MultiLevelPoisson{T};tol=1e-4,itmx=32,kwargs...) where T
+function solver!(ml::MultiLevelPoisson{T};tol=ml.tol,itmx=ml.itmx,kwargs...) where T
     p = ml.levels[1]
     residual!(p); r₂ = L₂(p); ω = T(1)
     nᵖ=0; @log ", $nᵖ, $(L∞(p)), $r₂, $ω\n"

--- a/src/Poisson.jl
+++ b/src/Poisson.jl
@@ -29,17 +29,27 @@ struct Poisson{T,S<:AbstractArray{T},V<:AbstractArray{T}} <: AbstractPoisson{T,S
     z :: S # source
     n :: Vector{Int16} # pressure solver iterations
     perdir :: NTuple # direction of periodic boundary condition
-    function Poisson(x::AbstractArray{T},L::AbstractArray{T},z::AbstractArray{T};perdir=()) where T
+    tol :: T # default solver tolerance
+    itmx :: Int # default maximum solver iterations
+    function Poisson(x::AbstractArray{T},L::AbstractArray{T},z::AbstractArray{T};perdir=(),tol=1e-4,itmx=1000) where T
         @assert axes(x) == axes(z) && axes(x) == Base.front(axes(L)) && last(axes(L)) == eachindex(axes(x))
         r = similar(x); fill!(r,0)
         ϵ,D,iD = copy(r),copy(r),copy(r)
         set_diag!(D,iD,L)
-        new{T,typeof(x),typeof(L)}(L,D,iD,x,ϵ,r,z,[],perdir)
+        new{T,typeof(x),typeof(L)}(L,D,iD,x,ϵ,r,z,[],perdir,T(tol),Int(itmx))
     end
 end
 
 using ForwardDiff: Dual,Tag
 Base.eps(::Type{D}) where D<:Dual{Tag{G,T}} where {G,T} = eps(T)
+"""
+    set_diag!(D, iD, L)
+
+Recompute the Poisson diagonal `D[I] = -Σⱼ (L[I,j] + L[I+δⱼ,j])` and its
+inverse `iD = 1/D` (zero where `D=0`, so masked cells stay masked).
+Called from the `Poisson` constructor and from `update!` whenever `L`
+changes (e.g. after the geometry is remeasured).
+"""
 function set_diag!(D,iD,L)
     @inside D[I] = diag(I,L)
     @inside iD[I] = iszero(D[I]) ? D[I] : inv(D[I])
@@ -97,6 +107,14 @@ function residual!(p::Poisson)
     @inside p.r[I] = p.r[I]-s
 end
 
+"""
+    increment!(p::Poisson; ω=1)
+
+Apply one relaxation increment in place: `x ← x + ω·ϵ` and the residual
+`r ← r - ω·A·ϵ`, kept in step. `ϵ` is the smoothing-step correction
+prepared by the caller (Jacobi or Gauss-Seidel); `ω` is the
+under-/over-relaxation factor (default `1` = no scaling).
+"""
 function increment!(p::Poisson{T};ω=1) where {T}
     perBC!(p.ϵ,p.perdir)
     @loop (p.r[I] = p.r[I]-ω*mult(I,p.L,p.D,p.ϵ);
@@ -181,7 +199,7 @@ L₂(p::Poisson) = p.r ⋅ p.r # special method since outside(p.r)≡0
 L∞(p::Poisson) = maximum(abs,p.r)
 
 """
-    solver!(A::Poisson;tol=1e-4,itmx=1e3)
+    solver!(A::Poisson;tol=A.tol,itmx=A.itmx)
 
 Approximate iterative solver for the Poisson matrix equation `Ax=b`.
 
@@ -189,10 +207,11 @@ Approximate iterative solver for the Poisson matrix equation `Ax=b`.
   - `A.x`: Solution vector. Can start with an initial guess.
   - `A.z`: Right-Hand-Side vector. Will be overwritten!
   - `A.n[end]`: stores the number of iterations performed.
-  - `tol`: Convergence tolerance on the `L₂`-norm residual.
-  - `itmx`: Maximum number of iterations.
+  - `tol`: Convergence tolerance on the `L₂`-norm residual. Defaults to
+    `A.tol` (set at construction); pass it explicitly to override per call.
+  - `itmx`: Maximum number of iterations. Defaults to `A.itmx`.
 """
-function solver!(p::Poisson;tol=1e-4,itmx=1e3, kwargs...)
+function solver!(p::Poisson;tol=p.tol,itmx=p.itmx, kwargs...)
     residual!(p); r₂ = L₂(p)
     nᵖ=0; @log ", $nᵖ, $(L∞(p)), $r₂, 1\n"
     while nᵖ<itmx

--- a/test/maintests.jl
+++ b/test/maintests.jl
@@ -107,10 +107,10 @@ backend != "KernelAbstractions" && throw(ArgumentError("SIMD backend not allowed
     end
 end
 
-function Poisson_setup(poisson,N::NTuple{D};f=Array,T=Float32, kwargs...) where D
+function Poisson_setup(poisson,N::NTuple{D};f=Array,T=Float32, cargs=(), kwargs...) where D
     c = ones(T,N...,D) |> f; BC!(c, ntuple(zero,D))
     x = zeros(T,N) |> f; z = copy(x)
-    pois = poisson(x,c,z)
+    pois = poisson(x,c,z; cargs...)
     soln = map(I->T(I.I[1]),CartesianIndices(N)) |> f
     I = first(inside(x))
     GPUArrays.@allowscalar @. soln -= soln[I]
@@ -135,6 +135,13 @@ end
         err,pois = Poisson_setup(Poisson,(2^4+2,2^4+2,2^4+2);f,tol=1e-6,itmx=6)
         @test err < 1e-1    # going down at least
         @test pois.n[] == 6 # should be 6
+        # tol/itmx stored on the struct are used when no kwargs are given,
+        # and a solver! kwarg still overrides them on the fly
+        err,pois = Poisson_setup(Poisson,(2^4+2,2^4+2,2^4+2);f,cargs=(tol=1e-6,itmx=6))
+        @test (pois.tol,pois.itmx) == (Float32(1e-6),6)
+        @test pois.n[] == 6 # stored itmx used by solver! with no kwargs
+        err,pois = Poisson_setup(Poisson,(2^4+2,2^4+2,2^4+2);f,cargs=(tol=1e-6,itmx=6),itmx=3)
+        @test pois.n[] == 3 # explicit kwarg overrides the stored itmx
     end
 end
 
@@ -161,6 +168,13 @@ end
         err,pois = Poisson_setup(MultiLevelPoisson,(2^4+2,2^4+2,2^4+2);f,tol=1e-8,itmx=2)
         @test err < 1e-5    # hits itmx first
         @test pois.n[] == 2 # should be 2
+        # tol/itmx stored on the struct are used when no kwargs are given,
+        # and a solver! kwarg still overrides them on the fly
+        err,pois = Poisson_setup(MultiLevelPoisson,(2^4+2,2^4+2,2^4+2);f,cargs=(tol=1e-8,itmx=2))
+        @test (pois.tol,pois.itmx) == (Float32(1e-8),2)
+        @test pois.n[] == 2 # stored itmx used by solver! with no kwargs
+        err,pois = Poisson_setup(MultiLevelPoisson,(2^4+2,2^4+2,2^4+2);f,cargs=(itmx=2,),itmx=1)
+        @test pois.n[] == 1 # explicit kwarg overrides the stored itmx
     end
 end
 


### PR DESCRIPTION
Builds on #245 — this PR targets its `poisson-solver-control` branch, not master.

#245 made `tol`/`itmx` settable per call via `solver!` kwargs (threaded through `sim_step!`/`mom_step!`). This adds the other half that was floated in the discussion — storing them on the solver struct as defaults — so the two compose:

- `Poisson` and `MultiLevelPoisson` gain `tol` / `itmx` fields, set via constructor kwargs. Defaults are unchanged (`Poisson` `1e-4`/`1000`, `MultiLevelPoisson` `1e-4`/`32`).
- `solver!` now defaults to `tol=p.tol, itmx=p.itmx`, so an explicit `solver!` / `sim_step!` / `mom_step!` kwarg still overrides on the fly — keeping the on-the-fly flexibility raised in the thread.

The motivation: a downstream solver that always needs a tighter tol (e.g. a VoF projection across a ρ-jump) can set it once at construction — through the `pois_ctor` escape hatch in `Simulation` — instead of re-passing it every step, while one-off overrides stay a kwarg.

Also documents the previously-undocumented `set_diag!` / `increment!` Poisson internals.

Tests (in the existing `Poisson` / `MultiLevelPoisson` testsets): the stored struct defaults are used by `solver!` when no kwargs are given, and an explicit `solver!` kwarg overrides them.
